### PR TITLE
expand simulator + nix packages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run tests
-      run: nix build -L --show-trace .#go-signs
+      run: nix build -L --show-trace .#go-signs-ci-release

--- a/README.md
+++ b/README.md
@@ -150,23 +150,6 @@ make build
 | `/sponsors/all`      | JSON list of all sponsor image filenames      |
 | `/sponsors/images/*` | Serves embedded sponsor image assets          |
 
-## Time Override for Development and Testing
-
-The web interface includes a powerful time simulation feature that's especially useful during development and testing. This allows you to preview how the schedule display would appear at any specific date and time without changing your system clock.
-
-Simply add the following URL parameters:
-
-```
-/?year=2025&month=3&day=20&hour=14&minute=30
-```
-
-This feature enables:
-
-- Testing schedule displays for future conference dates
-- Verifying session transition animations and status indicators
-- Confirming correct handling of "starting soon" and "in progress" states
-- Checking day transition logic and multi-day event displays
-
 ## Project Structure
 
 ```

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -29,9 +29,9 @@ inputs.nixpkgs.lib.genAttrs systems
 
     in
     {
-      go-signs = pkgs.buildGoModule rec {
-        pname = "go-signs";
-        version = "unstable";
+      go-signs-ci-release = pkgs.buildGoModule rec {
+        pname = "go-signs-ci";
+        version = "release";
         src = builtins.path { path = ../.; };
         goPackagePath = "github.com/kylerisse/go-signs";
 
@@ -93,9 +93,16 @@ inputs.nixpkgs.lib.genAttrs systems
           # copy all cross-compiled versions
           mkdir -p $out/bin
           for f in out/*; do
-            cp "$f" $out/bin/
+            cp "$f" $out/
           done
+          cd $out && sha256sum go-signs-* scale-simulator-* > $out/checksums.txt
         '';
+
+        meta = with lib; {
+          description = "go-signs CI release";
+          license = licenses.mit;
+          maintainers = [ "kylerisse" ];
+        };
       };
     }
   )

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -88,6 +88,37 @@ inputs.nixpkgs.lib.genAttrs systems
         };
       };
 
+      go-signs = pkgs.buildGoModule rec {
+        pname = "go-signs";
+        version = "unstable";
+        src = builtins.path { path = ../.; };
+        goPackagePath = "github.com/kylerisse/go-signs";
+        vendorHash = goSumSha;
+        nativeBuildInputs = defaultPackages ++ [ npmDeps ];
+
+        checkPhase = commonCheckPhase;
+
+        buildPhase = lib.strings.concatStrings [
+          reactBuild
+          ''
+            mkdir -p out
+            go build -o out/go-signs cmd/go-signs/main.go
+          ''
+        ];
+
+        installPhase = ''
+          mkdir -p $out/bin/
+          cp out/go-signs $out/bin/
+        '';
+
+        meta = with lib; {
+          description = "SCaLE Digital Signage App";
+          license = licenses.mit;
+          maintainers = [ "kylerisse" ];
+          mainProgram = "go-signs";
+        };
+      };
+
       go-signs-ci-release = pkgs.buildGoModule rec {
         pname = "go-signs-ci";
         version = "release";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -57,6 +57,37 @@ inputs.nixpkgs.lib.genAttrs systems
 
     in
     {
+      scale-simulator = pkgs.buildGoModule rec {
+        pname = "scale-simulator";
+        version = "unstable";
+        src = builtins.path { path = ../.; };
+        goPackagePath = "github.com/kylerisse/go-signs";
+        vendorHash = goSumSha;
+        nativeBuildInputs = defaultPackages ++ [ npmDeps ];
+
+        checkPhase = commonCheckPhase;
+
+        buildPhase = lib.strings.concatStrings [
+          reactBuild
+          ''
+            mkdir -p out
+            go build -o out/scale-simulator cmd/scale-simulator/main.go
+          ''
+        ];
+
+        installPhase = ''
+          mkdir -p $out/bin/
+          cp out/scale-simulator $out/bin/
+        '';
+
+        meta = with lib; {
+          description = "SCaLE Schedule Simulator";
+          license = licenses.mit;
+          maintainers = [ "kylerisse" ];
+          mainProgram = "scale-simulator";
+        };
+      };
+
       go-signs-ci-release = pkgs.buildGoModule rec {
         pname = "go-signs-ci";
         version = "release";

--- a/pkg/simulator/simulation.go
+++ b/pkg/simulator/simulation.go
@@ -58,8 +58,8 @@ func checkOrCreateSimulationBucket(db *bolt.DB) error {
 				}
 			}
 
-			// Then create a new endDate key with date 3 days from now (4 days including today)
-			endDateValue := today.AddDate(0, 0, 3).Format("2006-01-02")
+			// Then create a new endDate key with date 4 days from now (5 days including today)
+			endDateValue := today.AddDate(0, 0, 4).Format("2006-01-02")
 			if err := bucket.Put([]byte("endDate"), []byte(endDateValue)); err != nil {
 				return fmt.Errorf("failed to set endDate: %w", err)
 			}
@@ -202,12 +202,13 @@ func modifyXMLDates(xmlData []byte, today time.Time) ([]byte, error) {
 	}
 
 	// Map days to new dates
-	// Today = Thursday, Tomorrow = Friday, etc.
+	// Today = Wednesday, Tomorrow = Thursday, etc.
 	dates := make(map[string]time.Time)
-	dates["Thursday"] = today
-	dates["Friday"] = today.AddDate(0, 0, 1)
-	dates["Saturday"] = today.AddDate(0, 0, 2)
-	dates["Sunday"] = today.AddDate(0, 0, 3)
+	dates["Wednesday"] = today
+	dates["Thursday"] = today.AddDate(0, 0, 1)
+	dates["Friday"] = today.AddDate(0, 0, 2)
+	dates["Saturday"] = today.AddDate(0, 0, 3)
+	dates["Sunday"] = today.AddDate(0, 0, 4)
 
 	// Regular expression to find content attributes with dates/times
 	dateRegex := regexp.MustCompile(`content="([0-9]{4}-[0-9]{2}-[0-9]{2})T([0-9]{2}:[0-9]{2}:[0-9]{2})([-+][0-9]{2}:[0-9]{2})?"`)


### PR DESCRIPTION
The intention of `scale-simulator` is to power the demo site, which will run 24x7. It now has the following behavior:
- a simulated SCaLE will start using a random previous year as it's baseline for "today" where "today" is equivalent to the Wednesday of that particular year instead of Thursday.
- In addition to the time shifted copy of a previous year with current dates, every single previous SCaLE between `13x` and `22x` is now part of the simulation. This will allow demo site users to view any point in the last decade+ of SCaLE history using time shifting URL parameters.
- A background scheduled task now runs every 5 minutes to not only detect if the simulated SCaLE has ended, but also if the simulated schedule no longer has topics. This has the effect of once the simulated "Sunday" no longer has talks, it will immediately start a new simulation and become the "Wednesday".

Nix Packages have been added for the following:
- `go-signs` is now just the binary meant to run on pis and any "servers" deemed necessary
- `scale-simulator` is intended for consumption by the demo server and potentially developers
- `go-signs-ci-release` is the renamed cross compile build meant for consumption as eventual Github Releases. A checksum file has been added to be placed with these artifacts.

TODO for `0.1.0`:
- create `nixos-modules` for `scale-simulator` and `go-signs`
- launch demo site
- add Github actions for consuming and releasing the output of `go-signs-ci-releases`
- additional documentation (scale-simulator, links to live demo site, release roadmap post `0.1.0`, etc)

flake output:
```
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
└───packages
    ├───aarch64-darwin
    │   ├───go-signs: package 'go-signs-unstable'
    │   ├───go-signs-ci-release: package 'go-signs-ci-release'
    │   └───scale-simulator: package 'scale-simulator-unstable'
    ├───aarch64-linux
    │   ├───go-signs: package 'go-signs-unstable'
    │   ├───go-signs-ci-release: package 'go-signs-ci-release'
    │   └───scale-simulator: package 'scale-simulator-unstable'
    └───x86_64-linux
        ├───go-signs: package 'go-signs-unstable'
        ├───go-signs-ci-release: package 'go-signs-ci-release'
        └───scale-simulator: package 'scale-simulator-unstable'
```
