### PR TITLE
Allow Partial URL Parameters

### DIFF
--- a/react-display/src/contexts/TimeContext/TimeProvider.tsx
+++ b/react-display/src/contexts/TimeContext/TimeProvider.tsx
@@ -15,35 +15,22 @@ export function TimeProvider({ children }: TimeProviderProps) {
 		// Get initial time based on URL parameters or current time
 		const getInitialTime = (): Date => {
 			const params = new URLSearchParams(window.location.search);
+			const now = new Date();
 
 			const year = parseInt(params.get('year') ?? '', 10);
-			const month = parseInt(params.get('month') ?? '', 10) - 1; // 0-indexed month
+			const month = parseInt(params.get('month') ?? '', 10);
 			const day = parseInt(params.get('day') ?? '', 10);
 			const hour = parseInt(params.get('hour') ?? '', 10);
 			const minute = parseInt(params.get('minute') ?? '', 10);
 
-			// All parameters must be valid to create a custom time
-			if (
-				!isNaN(year) &&
-				!isNaN(month) &&
-				!isNaN(day) &&
-				!isNaN(hour) &&
-				!isNaN(minute)
-			) {
-				const customDate = new Date();
-
-				customDate.setFullYear(year);
-				customDate.setMonth(month);
-				customDate.setDate(day);
-				customDate.setHours(hour);
-				customDate.setMinutes(minute);
-				customDate.setSeconds(0);
-
-				return customDate;
-			}
-
-			// Otherwise, use current time
-			return new Date();
+			return new Date(
+				isNaN(year) ? now.getFullYear() : year,
+				isNaN(month) ? now.getMonth() : month - 1, // 0-indexed month
+				isNaN(day) ? now.getDate() : day,
+				isNaN(hour) ? now.getHours() : hour,
+				isNaN(minute) ? now.getMinutes() : minute,
+				now.getSeconds(),
+			);
 		};
 
 		// Calculate the offset between initial time and actual time


### PR DESCRIPTION
Fixes #55

## Description of PR

Partial date parameters supplied in the URL will now merge with actual values from `now` to make development more enjoyable. Because time shifting is mainly for development there is no attempt to bound integer values and they simply pass them straight through to Date library for better or worse. Non-numbers are ignored. Thank you to @carlynlee for working on this.

## Previous Behavior

Every URL parameter was required to create a time shifted customer date. (year, month, day, hour, minute)

## New Behavior

Developer can choose to omit certain values and the result with be what is expected. For example `http://localhost/?month=3` would only change the month but keep the current year, day, hour, and minute. This works for any combination of values.

## Tests

- mainly UI testing
